### PR TITLE
Added slice to xos-core along with django-specific types

### DIFF
--- a/schema/xos-core.yang
+++ b/schema/xos-core.yang
@@ -28,6 +28,7 @@ module xos-core {
   
   import ietf-yang-types { prefix yang; }
   import ietf-inet-types { prefix inet; }
+  import xos-types { prefix xos; }
 
   feature synchronizer {
     description
@@ -260,6 +261,89 @@ module xos-core {
 
     // TODO: should be able to deal with TenantWithContainer here
     
+  }
+
+  grouping slice {
+    description 
+      "A slice is a logically centralized container for network and compute resources"
+
+    uses base-common;
+
+    leaf enabled {
+       type boolean;
+       default true;
+    }
+
+    leaf omf-friendly {
+       type boolean;
+       default false;
+       status deprecated;
+    }
+
+    leaf slice-url {
+       description "A URL describing the purpose of this slice";
+       type xos.refs.url-field; 
+       // blank true;
+    }
+
+    leaf max-instances {
+       description "The maximum number of VMs that this slice is allowed to allocate";
+       type uint32;
+    } 
+
+    leaf service {
+       description "The service that runs in this slice";
+       type xos.refs.service;
+    }
+
+    leaf network {
+       description "The network that the slice uses to connect to other slices and to the Internet.";
+       type string;
+    }
+
+    leaf exposed-ports {
+       description "The ports to be exposed for other slices to connect to";
+       type string;
+    }
+
+    leaf service-class {
+       type xos.refs.service-class;
+       status deprecated;
+    }
+   
+    leaf creator {
+       type xos.refs.user;
+    }
+
+    leaf default-flavor {
+       type xos.refs.flavor;
+    }
+
+    leaf default-image {
+       type xos.refs.image;
+    }
+
+    leaf default-node {
+       type xos.refs.node;
+    } 
+
+    leaf mount-data-sets {
+       type string;
+       default "GenBank";
+       length 0..256;
+    } 
+
+    leaf default_isolation {
+       type string;
+       default "vm";
+       length 0..30;
+    } 
+
+    leaf-list tags {
+        type leafref {
+            path "/tag[id = current()/../id]/id";
+        }
+    }
   }
   
   /*** main configuration tree for XOS ***/

--- a/schema/xos-types.yang
+++ b/schema/xos-types.yang
@@ -1,0 +1,297 @@
+module xos-types {
+  namespace "urn:onlab:xos:types";
+  prefix xos-types;
+  yang-version 1.1;
+
+  organization
+   "Open Networking Lab (CORD) / Corenova Technologies";
+
+  contact
+    "Larry Peterson <llp@onlab.us>
+     Peter K. Lee <peter@corenova.com>";
+  
+  import ietf-yang-types { prefix yang; }
+  
+  revision 2016-09-12 {
+    description "Initial revision.";
+  }
+
+  grouping unique-identifier {
+    description "defines valid formats for external reference id";
+    type union {
+      type uint32 { range 1..max; }
+      type yang:uuid;
+      type inet:uri;
+    }
+  }
+
+  container refs {
+    grouping image {
+      uses unique-identifier;
+    }
+
+    grouping controller-network {
+      uses unique-identifier;
+    }
+
+    grouping site {
+      uses unique-identifier;
+    }
+
+    grouping tenant-root-role {
+      uses unique-identifier;
+    }
+
+    grouping slice-role {
+      uses unique-identifier;
+    }
+
+    grouping site-deployment {
+      uses unique-identifier;
+    }
+
+    grouping tenant-privilege {
+      uses unique-identifier;
+    }
+
+    grouping tag {
+      uses unique-identifier;
+    }
+
+    grouping user-credential {
+      uses unique-identifier;
+    }
+
+    grouping invoice {
+      uses unique-identifier;
+    }
+
+    grouping slice-privilege {
+      uses unique-identifier;
+    }
+
+    grouping flavor {
+      uses unique-identifier;
+    }
+
+    grouping port {
+      uses unique-identifier;
+    }
+
+    grouping service-role {
+      uses unique-identifier;
+    }
+
+    grouping controller-site {
+      uses unique-identifier;
+    }
+
+    grouping controller-slice {
+      uses unique-identifier;
+    }
+
+    grouping tenant-role {
+      uses unique-identifier;
+    }
+
+    grouping slice {
+      uses unique-identifier;
+    }
+
+    grouping network {
+      uses unique-identifier;
+    }
+
+    grouping controller-role {
+      uses unique-identifier;
+    }
+
+    grouping diag {
+      uses unique-identifier;
+    }
+
+    grouping service-class {
+      uses unique-identifier;
+    }
+
+    grouping tenant-attribute {
+      uses unique-identifier;
+    }
+
+    grouping site-role {
+      uses unique-identifier;
+    }
+
+    grouping subscriber {
+      uses unique-identifier;
+    }
+
+    grouping instance {
+      uses unique-identifier;
+    }
+
+    grouping charge {
+      uses unique-identifier;
+    }
+
+    grouping program {
+      uses unique-identifier;
+    }
+
+    grouping role {
+      uses unique-identifier;
+    }
+
+    grouping usable-object {
+      uses unique-identifier;
+    }
+
+    grouping node-label {
+      uses unique-identifier;
+    }
+
+    grouping slice-credential {
+      uses unique-identifier;
+    }
+
+    grouping node {
+      uses unique-identifier;
+    }
+
+    grouping address-pool {
+      uses unique-identifier;
+    }
+
+    grouping dashboard-view {
+      uses unique-identifier;
+    }
+
+    grouping network-parameter {
+      uses unique-identifier;
+    }
+
+    grouping image-deployments {
+      uses unique-identifier;
+    }
+
+    grouping controller-user {
+      uses unique-identifier;
+    }
+
+    grouping reserved-resource {
+      uses unique-identifier;
+    }
+
+    grouping network-template {
+      uses unique-identifier;
+    }
+
+    grouping controller-dashboard-view {
+      uses unique-identifier;
+    }
+
+    grouping user-dashboard-view {
+      uses unique-identifier;
+    }
+
+    grouping controller {
+      uses unique-identifier;
+    }
+
+    grouping user {
+      uses unique-identifier;
+    }
+
+    grouping deployment {
+      uses unique-identifier;
+    }
+
+    grouping reservation {
+      uses unique-identifier;
+    }
+
+    grouping site-privilege {
+      uses unique-identifier;
+    }
+
+    grouping payment {
+      uses unique-identifier;
+    }
+
+    grouping tenant {
+      uses unique-identifier;
+    }
+
+    grouping network-slice {
+      uses unique-identifier;
+    }
+
+    grouping account {
+      uses unique-identifier;
+    }
+
+    grouping tenant-root {
+      uses unique-identifier;
+    }
+
+    grouping service {
+      uses unique-identifier;
+    }
+
+    grouping controller-slice-privilege {
+      uses unique-identifier;
+    }
+
+    grouping site-credential {
+      uses unique-identifier;
+    }
+
+    grouping deployment-privilege {
+      uses unique-identifier;
+    }
+
+    grouping network-parameter-type {
+      uses unique-identifier;
+    }
+
+    grouping provider {
+      uses unique-identifier;
+    }
+
+    grouping tenant-with-container {
+      uses unique-identifier;
+    }
+
+    grouping deployment-role {
+      uses unique-identifier;
+    }
+
+    grouping project {
+      uses unique-identifier;
+    }
+
+    grouping tenant-root-privilege {
+      uses unique-identifier;
+    }
+
+    grouping slice-tag {
+      uses unique-identifier;
+    }
+
+    grouping coarse-tenant {
+      uses unique-identifier;
+    }
+
+    grouping router {
+      uses unique-identifier;
+    }
+
+    grouping service-resource {
+      uses unique-identifier;
+    }
+
+    grouping service-privilege {
+      uses unique-identifier;
+    }
+  }
+}


### PR DESCRIPTION
In order to interoperate with django, we would need a way to map YANG types back to Django types. For primitives (string, int etc.) it's easy. But additional qualifications are needed for xos types, and for other complex types such as urls, bits etc.
